### PR TITLE
Trimming Data Removes All Line Breaks

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -85,7 +85,8 @@ var Tesseract = {
           fs.unlink(outputFile);
 
           // Trim leading & trailing whitespace from returned text
-          data = utils.trim(data);
+          // Trimming the data disables support for multi-line documents.  Leave this to the implementor.
+          //data = utils.trim(data);
 
           callback(err, data);
         }); // end reaFile


### PR DESCRIPTION
Trimming data removes all line breaks thus breaking support for multi-line documents.  Text parsing should be left to consuming applications.
