### PR TITLE
we don't care if a file has already been removed, when trying to remove it

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -102,7 +102,10 @@ var Tesseract = {
 
 function gc() {
   for (var i = Tesseract.tmpFiles.length - 1; i >= 0; i--) {
-    fs.unlinkSync(Tesseract.tmpFiles[i] + '.txt');
+    try {
+      fs.unlinkSync(Tesseract.tmpFiles[i] + '.txt');
+    } catch (err) {}
+
     var index = Tesseract.tmpFiles.indexOf(Tesseract.tmpFiles[i]);
     if (~index) Tesseract.tmpFiles.splice(index, 1);
   };


### PR DESCRIPTION
When removing the temporary file, if it's already been removed, don't throw and error. We can safely do this because we are attempting to remove the file anyway, so it makes no difference if it's already been removed.
