### PR TITLE
Replace temporary Files with tesseract stdin/stdout

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -4,16 +4,10 @@
  * Module dependencies.
  */
 var utils = require('./utils');
-var exec = require('child_process').exec;
-var fs = require('fs');
-var tmpdir = require('os').tmpdir(); // let the os take care of removing zombie tmp files
-var uuid = require('node-uuid');
-var path = require('path');
+var spawn = require('child_process').spawn;
+var createReadStream = require('fs').createReadStream;
 
 var Tesseract = {
-
-  tmpFiles: [],
-
   /**
    * options default options passed to Tesseract binary
    * @type {Object}
@@ -26,108 +20,74 @@ var Tesseract = {
   },
 
   /**
-   * outputEncoding
-   * @type {String}
-   */
-  outputEncoding: 'UTF-8',
-
-  /**
-   * Runs Tesseract binary with options
+   * Create Stream from path, then run processStream
    *
    * @param {String} image
    * @param {Object} options to pass to Tesseract binary
    * @param {Function} callback
+   * @returns {Stream}
    */
   process: function(image, options, callback) {
+    return this.processStream(createReadStream(image), options, callback);
+  },
+
+  
+
+  /**
+   * Runs Tesseract binary with options
+   *
+   * @param {Stream} image
+   * @param {Object} options to pass to Tesseract binary
+   * @param {Function} callback
+   * @returns {Stream}
+   */
+  processStream: function(image, options, callback) {
 
     if (typeof options === 'function') {
       callback = options;
       options = null;
     }
-
     options = utils.merge(Tesseract.options, options);
 
-    // generate output file name
-    var output = path.resolve(tmpdir, 'node-tesseract-' + uuid.v4());
-
-    // add the tmp file to the list
-    Tesseract.tmpFiles.push(output);
-
     // assemble tesseract command
-    var command = [options.binary, image, output];
+    var command = '- -';
 
     if (options.l !== null) {
-      command.push('-l ' + options.l);
+      command += ' -l ' + options.l;
     }
 
     if (options.psm !== null) {
-      command.push('-psm ' + options.psm);
+      command += ' -psm ' + options.psm;
     }
 
     if (options.config !== null) {
-      command.push(options.config);
+      command += ' ' + options.config;
     }
 
-    command = command.join(' ');
+    var bin = spawn(Tesseract.options.binary, command.split(' ')),
+      body = '', 
+      errbody = '',
+      done = false;
 
-    var opts = options.env || {};
+    image.pipe(bin.stdin);
 
-    // Run the tesseract command
-    exec(command, opts, function(err) {
-      if (err) {
-        // Something went wrong executing the assembled command
-        callback(err, null);
-        return;
-      }
-
-      var outputFile = output + '.txt';
-      fs.readFile(outputFile, function(err, data) {
-        if (!err) {
-          // There was no error, so get the text
-          data = data.toString(Tesseract.outputEncoding);
-        }
-        fs.unlink(outputFile);
-        // remove the file from the tmpFiles array
-        var index = Tesseract.tmpFiles.indexOf(output);
-        if (~index) Tesseract.tmpFiles.splice(index, 1);
-
-        callback(err, data);
-      }); // end reaFile
-
-    }); // end exec
-
+    if (callback) {
+      bin.stdout.on('data', function(chunk) {
+        body += chunk;
+      });
+      bin.stderr.on('data', function(chunk) {
+        errbody += chunk;
+      });
+      bin.on('exit', function() {
+          callback(errbody, body);
+      });
+    }
+    return bin.stdout;
   }
 
 };
-
-function gc() {
-  for (var i = Tesseract.tmpFiles.length - 1; i >= 0; i--) {
-    try {
-      fs.unlinkSync(Tesseract.tmpFiles[i] + '.txt');
-    } catch (err) {}
-
-    var index = Tesseract.tmpFiles.indexOf(Tesseract.tmpFiles[i]);
-    if (~index) Tesseract.tmpFiles.splice(index, 1);
-  };
-}
-
-var version = process.versions.node.split('.').map(function(value) {
-  return parseInt(value, 10);
-});
-
-if (version[0] === 0 && (version[1] < 9 || version[1] === 9 && version[2] < 5)) {
-  process.addListener('uncaughtException', function _uncaughtExceptionThrown(err) {
-    gc();
-    throw err;
-  });
-}
-
-// clean up the tmp files
-process.addListener('exit', function _exit(code) {
-  gc();
-});
-
 /**
  * Module exports.
  */
 module.exports.process = Tesseract.process;
+module.exports.processStream = Tesseract.processStream;

--- a/test/tesseract.js
+++ b/test/tesseract.js
@@ -14,6 +14,20 @@ describe('process', function(){
       done();
     });
 
+  });
+
+  it('should return the string "node-tesseract" when run with options', function(done){
+
+  var testImage = __dirname + '/test.png';
+
+  tesseract.process(testImage, {
+    psm:3,
+    l:'eng'
+  }, function(err, text) {
+    text.trim().should.equal('node-tesseract');
+    done();
+  });
+
   })
 })
 


### PR DESCRIPTION
This change introduces Tesseract.processStream() to simplify usage with build tools and reduce I/O.
Tesseract.process() uses it but – except for an added return value – should remain compatible. (The tests pass, but I did not use it with options.config explicitly.) 
I also felt like adding another small test case.