### PR TITLE
Add a function to enable tesseract stdin and stdout argument parameters

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -10,6 +10,8 @@ var tmpdir = require('os').tmpdir(); // let the os take care of removing zombie 
 var uuid = require('node-uuid');
 var path = require('path');
 var glob = require("glob");
+var spawn = require('child_process').spawn;
+
 
 var Tesseract = {
 
@@ -31,6 +33,41 @@ var Tesseract = {
    * @type {String}
    */
   outputEncoding: 'UTF-8',
+
+  /**
+   * Runs Tesseract binary with options
+   *
+   * @param {String} stream
+   * @param {Object} options to pass to Tesseract binary
+   * @param {Function} callback
+   */
+  processStream: function(stream, options, callback) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = null;
+      }
+
+      options = utils.merge(Tesseract.options, options);
+
+      var tesseract = spawn('tesseract', ['stdin', 'stdout', '-l', options.l, '-psm', options.psm])
+      stream.pipe(tesseract.stdin);
+
+      var data = '';
+      tesseract.stdout.on('data', function(chunk) {
+        data += chunk;
+      });
+      tesseract.stderr.on('data', function(chunk) {
+        data += chunk;
+      });
+      tesseract.on('exit', function(chunk) {
+        callback(null, data);
+      });
+      tesseract.on('error', function(chunk) {
+        if (tesseract) {
+          tesseract.kill();
+        }
+      });
+  },
 
   /**
    * Runs Tesseract binary with options
@@ -138,3 +175,4 @@ process.addListener('exit', function _exit(code) {
  * Module exports.
  */
 module.exports.process = Tesseract.process;
+module.exports.processStream = Tesseract.processStream;

--- a/test/tesseract.js
+++ b/test/tesseract.js
@@ -2,6 +2,7 @@
 
 var tesseract = require('../lib/tesseract');
 var should = require('should');
+var fs = require('fs');
 
 
 describe('process', function(){
@@ -14,6 +15,18 @@ describe('process', function(){
       done();
     });
 
-  })
-})
+  });
+
+  it('should return the string "node-tesseract"', function(done){
+
+    var testImage = __dirname + '/test.png';
+
+    tesseract.processStream(fs.createReadStream(testImage), function(err, text) {
+      text.trim().should.equal('node-tesseract');
+      done();
+    });
+
+  });
+
+});
 


### PR DESCRIPTION
Introduces a new function processStream() that pipes read streams into a child process executing the tesseract binary. Process() is unchanged to keep any backwards compatibility. Included a test case as well.

Usage:
```
  tesseract.processStream(stream, options, callback)
```