### PR TITLE
Add feature selection (hocr/tsv)

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -23,7 +23,8 @@ var Tesseract = {
     'l': 'eng',
     'psm': 3,
     'config': null,
-    'binary': 'tesseract'
+    'binary': 'tesseract',
+    'format': null
   },
 
   /**
@@ -67,6 +68,11 @@ var Tesseract = {
 
     if (options.config !== null) {
       command.push(options.config);
+    }
+
+    var validFormats = ['hocr', 'tsv'];
+    if (options.format !== null && validFormats.indexOf(options.format) > -1) {
+      command.push(options.format);
     }
 
     command = command.join(' ');

--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -71,8 +71,8 @@ var Tesseract = {
     }
 
     var validFormats = ['hocr', 'tsv'];
-    if (options.format !== null && validFormats.indexOf(options.format) > -1) {
-      command.push(options.format);
+    if (options.format !== null && validFormats.indexOf(options.format.toLowerCase()) > -1) {
+      command.push(options.format.toLowerCase());
     }
 
     command = command.join(' ');


### PR DESCRIPTION
I noticed that there didn't seem to be a way for node-tesseract to specify whether it should generate output in either HOCR or TSV. This PR provides a new option - `format` - which can be either "hocr" or "tsv" to specify one output format or the other. If it's absent, it outputs plain text as normal.

Let me know if you'd prefer there to be another way to determine the output format - such as inference from the output file suffix?