### PR TITLE
Support psm 0

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -56,6 +56,9 @@ var Tesseract = {
 
     // assemble tesseract command
     var command = [options.binary, image, output];
+    if (options.psm == 0) {
+      command = [options.binary, image, 'stdout'];
+    }
 
     if (options.l !== null) {
       command.push('-l ' + options.l);
@@ -74,7 +77,7 @@ var Tesseract = {
     var opts = options.env || {};
 
     // Run the tesseract command
-    exec(command, opts, function(err) {
+    var childProcess = exec(command, opts, function(err) {
       if (err) {
         // Something went wrong executing the assembled command
         callback(err, null);
@@ -98,14 +101,49 @@ var Tesseract = {
 
           fs.unlink(files[0]);
 
+          if (options.psm == 0) {
+            data = parseOsdOutput(data);
+          }
           callback(null, data)
         });
       })
     }); // end exec
 
+    if (options.psm == 0) {
+      childProcess.stderr.pipe(fs.createWriteStream(output + '.txt'));
+    }
+
   }
 
 };
+
+function parseOsdOutput(string) {
+  return string
+    .split('\n')
+    .reduce(function(obj, line) {
+      var result;
+
+      result = /Orientation in degrees: (\d+)/.exec(line);
+      if (result) {
+        obj.orientation = parseInt(result[1]);
+        return obj;
+      }
+
+      result = /Orientation confidence: (\d+(\.\d+))/.exec(line);
+      if (result) {
+        obj.orientationConfidence = parseFloat(result[1]);
+        return obj;
+      }
+
+      result = /Script confidence: (\d+(\.\d+))/.exec(line);
+      if (result) {
+        obj.scriptConfidence = parseFloat(result[1]);
+        return obj;
+      }
+
+      return obj;
+    }, {});
+}
 
 function gc() {
   for (var i = Tesseract.tmpFiles.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Original version will fail if psm is set to 0. Now it will return a object representing the result. 