### PR TITLE
bugfix: don't override default settings from incoming parameters

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -46,7 +46,8 @@ var Tesseract = {
       options = null;
     }
 
-    options = utils.merge(Tesseract.options, options);
+    var defaultOptions = utils.merge({}, Tesseract.options);
+    options = utils.merge(defaultOptions, options);
 
     // generate output file name
     var output = path.resolve(tmpdir, 'node-tesseract-' + uuid.v4());


### PR DESCRIPTION
If some additional parameters are given for `process()`, for example:

```
Tesseract.processAsync(fileName, {psm: 7}).then((text) => {
    console.log(text);
});
```

On the next call:

```
Tesseract.processAsync(fileName).then((text) => {
    console.log(text);
});
```

`psm` value will be `7`, because the `Tesseract.options` object gets altered on each `process` call.
