### PR TITLE
Changed fs.unlink() -> fs.unlinkSync()

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -96,7 +96,7 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlink(files[0]);
+          fs.unlinkSync(files[0]);
 
           callback(null, data)
         });


### PR DESCRIPTION
Updated the call to `fs.unlink(files[0])` to remove deprecation warnings on later versions of node.

`fs.unlink(files[0])` -> `fs.unlinkSync(files[0])`