### PR TITLE
fix DeprecationWarning

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -97,7 +97,7 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlinkSync(files[0]);
+          fs.unlinkSync(files[0], function() {});
 
           callback(null, data)
         });


### PR DESCRIPTION
the error "DeprecationWarning: Calling an asynchronous function without callback is deprecated" was caused by fs.unlink funciton not having a callback function