### PR TITLE
Add required callback to fs.unlink()

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -97,7 +97,9 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlinkSync(files[0]);
+          fs.unlinkSync(files[0], function(err) {
+            if (err) throw err;
+          });
 
           callback(null, data)
         });


### PR DESCRIPTION
* fs.unlink() expects a callback as its second parameter. [Docs](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback)
* This commit adds a simple callback that will throw an error if an error occurs.