### PR TITLE
Allow image file paths to contain spaces

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -56,7 +56,7 @@ var Tesseract = {
     Tesseract.tmpFiles.push(output);
 
     // assemble tesseract command
-    var command = [options.binary, image, output];
+    var command = [options.binary, `"${image}"`, output];
 
     if (options.l !== null) {
       command.push('-l ' + options.l);

--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -56,7 +56,7 @@ var Tesseract = {
     Tesseract.tmpFiles.push(output);
 
     // assemble tesseract command
-    var command = [options.binary, `"${image}"`, output];
+    var command = [options.binary, '"' + image + '"', output];
 
     if (options.l !== null) {
       command.push('-l ' + options.l);


### PR DESCRIPTION
Without this, in Windows, the command will fail.