### PR TITLE
Fixing DEP0013

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -96,13 +96,13 @@ var Tesseract = {
 
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
-
+		
           fs.unlink(files[0], function(err) {
-			      if (err) { 
+            if (err) { 
               callback(err, null);
               return;
             }
-		      });
+          });
 
           callback(null, data)
         });

--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -97,7 +97,12 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlinkSync(files[0]);
+          fs.unlink(files[0], function(err) {
+			      if (err) { 
+              callback(err, null);
+              return;
+            }
+		      });
 
           callback(null, data)
         });


### PR DESCRIPTION
This change stops Node JS from complaining about a violation of DEP0013 (fs asynchronous function without callback) by fixing the problem. It adds a callback to fs.unsync, it uses the same method the rest of the code uses to handle errors.