### PR TITLE
Remove Warning about Deprecated calling function

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -97,7 +97,7 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlinkSync(files[0]);
+          fs.unlink(files[0], () => { /**/});
 
           callback(null, data)
         });


### PR DESCRIPTION
`[DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.`

`s.unlinkSync` should call with a callback. I add an empty callback function to avoid the warning.