### PR TITLE
Replace deprecated usage of fs.unlink with fs.unlinkSync, and make compatible with tesseract 4

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -7,7 +7,7 @@ var utils = require('./utils');
 var exec = require('child_process').exec;
 var fs = require('fs');
 var tmpdir = require('os').tmpdir(); // let the os take care of removing zombie tmp files
-var uuid = require('uuid');
+var uuid = require('node-uuid');
 var path = require('path');
 var glob = require("glob");
 
@@ -46,8 +46,7 @@ var Tesseract = {
       options = null;
     }
 
-    var defaultOptions = utils.merge({}, Tesseract.options);
-    options = utils.merge(defaultOptions, options);
+    options = utils.merge(Tesseract.options, options);
 
     // generate output file name
     var output = path.resolve(tmpdir, 'node-tesseract-' + uuid.v4());
@@ -63,7 +62,7 @@ var Tesseract = {
     }
 
     if (options.psm !== null) {
-      command.push('-psm ' + options.psm);
+      command.push('--psm ' + options.psm);
     }
 
     if (options.config !== null) {


### PR DESCRIPTION
With node v10, a callback is required with fs.unlink, resulting in an error with the current code. I have replaced the call to fs.unlink with fs.unlinkSync.

Also, with tesseract 4, it seems that an additional hyphen is required for the "psm" argument. I have added this as well.