### PR TITLE
Update tesseract.js

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -63,7 +63,7 @@ var Tesseract = {
     }
 
     if (options.psm !== null) {
-      command.push('-psm ' + options.psm);
+      command.push('--psm ' + options.psm);
     }
 
     if (options.config !== null) {


### PR DESCRIPTION
`-psm` option is deprecated. Switched to `--psm` for the latest OCR