### PR TITLE
Updating to work with Tesseract 5

### DIFF
--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -63,7 +63,7 @@ var Tesseract = {
     }
 
     if (options.psm !== null) {
-      command.push('-psm ' + options.psm);
+      command.push('--psm ' + options.psm);
     }
 
     if (options.config !== null) {
@@ -97,7 +97,9 @@ var Tesseract = {
           var index = Tesseract.tmpFiles.indexOf(output);
           if (~index) Tesseract.tmpFiles.splice(index, 1);
 
-          fs.unlinkSync(files[0]);
+          fs.unlinkSync(files[0], function(err) {
+            if (err) callback(err, null);
+          });
 
           callback(null, data)
         });


### PR DESCRIPTION
The -psm argument has been deprecated and replaced with the --psm argument, as noted here: https://github.com/openpaperwork/pyocr/issues/99
Further, on Line 99 fs.unlink() was being called without a callback, which in the current version of Node throws a fatal error.